### PR TITLE
Fixes context.md swapping _value and value

### DIFF
--- a/advanced/context.md
+++ b/advanced/context.md
@@ -11,7 +11,7 @@ FormKit inputs use a reactive object to expose data to template slots, rules, an
 
 ## `_value`
 
-FormKit inputs have two values — the committed value (`node._value`) and the uncommitted value (`node.value`). At rest, these two values are equivalent, but the uncommitted value is the undebounced raw value of the input.
+FormKit inputs have two values — the committed value (`node.value`) and the uncommitted value (`node._value`). At rest, these two values are equivalent, but the uncommitted value is the undebounced raw value of the input.
 
 ## `attrs`
 


### PR DESCRIPTION
Both advanced/custom-input.md and code ([packages/core/src/node.ts](https://github.com/formkit/formkit/blob/12f2405b827a71fa828e82b1d3b053c92d061f6f/packages/core/src/node.ts#L467)) states that `value`  is the committed value while `_value` is the uncommitted undebounced value, and context.md had those two explanations swapped.