### PR TITLE
docs: :memo: adds warning about tailwindcss content property

### DIFF
--- a/guides/create-a-tailwind-theme.md
+++ b/guides/create-a-tailwind-theme.md
@@ -50,6 +50,10 @@ From there we need to do two things:
 
 <client-only>
 
+<callout type="warning" label="Formkit configuration outside app.js">
+When using a single file for configuration like <code>formkit.config.js</code> instead of <code>app.js</code>, you should make sure to add to <code>tailwind.config.js</code> inside <code>content</code> the path to that file.
+</callout>
+
 ```js
 // tailwind.config.js
 module.exports {


### PR DESCRIPTION
adds warning about the need of adding to the tailwindcss configuration file the content property with the path to the formkit configuration file