### PR TITLE
Change the order of the imports.

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -92,8 +92,8 @@ The `@formkit/vue` package ships with a Vue plugin and a default configuration f
 
 ```js
 import { createApp } from 'vue'
-import App from 'App.vue'
 import { plugin, defaultConfig } from '@formkit/vue'
+import App from 'App.vue'
 
 createApp(App).use(plugin, defaultConfig).mount('#app')
 ```


### PR DESCRIPTION
So that the FormKit import is before the App import. Otherwise the components would not be rendered.