### PR TITLE
fix: Dead link (`/inputs/forms/` → `/input/form/`)

### DIFF
--- a/inputs/group.md
+++ b/inputs/group.md
@@ -42,7 +42,7 @@ Even though a `group` can have validation rules and input errors, it does not in
 type: "tip"
 label: "Configuration"
 ---
-Further documentation on the <code>FormKitMessages</code> component can be found on the <a href="/inputs/forms#moving-validation-and-error-messages">form documentation page</a>.
+Further documentation on the <code>FormKitMessages</code> component can be found on the <a href="/inputs/form#moving-validation-and-error-messages">form documentation page</a>.
 ::
 
 ## Props & Attributes


### PR DESCRIPTION
Hey, this page has a dead link: 
<https://formkit.com/inputs/group#showing-error-validation-messages>

From what I can tell, this is the only reference to `inputs/forms` instead of `inputs/form`: ![](https://frogg.ie/RH3)