### PR TITLE
Fixes class removal syntax

### DIFF
--- a/_examples/removing-classes/removing-classes.vue
+++ b/_examples/removing-classes/removing-classes.vue
@@ -6,7 +6,7 @@
     }"
   />
   <FormKit 
-    outer-class="!formkit-outer"
+    outer-class="$remove:formkit-outer"
   />
   <!-- %partial%::html:: -->
 </template>


### PR DESCRIPTION
I noticed that the [Removing classes](https://formkit.com/essentials/styling#removing-classes) documentation uses incorrect syntax. It uses `outer-class="!formkit-outer"` which results in `class="formkit-outer !formkit-outer"` instead of actually removing the class.

(The correct syntax is `outer-class="$remove:formkit-outer"`)