### PR TITLE
Changing props name from prev-label to previous-label

### DIFF
--- a/_examples/multi-step/step-labels/step-labels.vue
+++ b/_examples/multi-step/step-labels/step-labels.vue
@@ -10,7 +10,7 @@
       <FormKit type="text" label="Name" />
     </FormKit>
 
-    <FormKit type="step" name="stepTwo" prev-label="Go back to previous step">
+    <FormKit type="step" name="stepTwo" previous-label="Go back to previous step">
       <FormKit type="textarea" label="Your story" />
     </FormKit>
     <!-- %partial% -->

--- a/plugins/multi-step.md
+++ b/plugins/multi-step.md
@@ -91,10 +91,10 @@ file: [
 
 ## Step labels
 
-By default the `multi-step` input will use the `name` attribute of its child `step` inputs to generate labels for steps. If you'd like more control over the display of your step names you can use the `label` prop. You can also customize the labels that appear in the `stepActions` section of your `step` using the `prev-label` and `next-label` props.
+By default the `multi-step` input will use the `name` attribute of its child `step` inputs to generate labels for steps. If you'd like more control over the display of your step names you can use the `label` prop. You can also customize the labels that appear in the `stepActions` section of your `step` using the `previous-label` and `next-label` props.
 
 - `label`: An override for the step name that should appear in the multi-step tabs.
-- `prev-label`: an override for the `stepPrevious` button label which defaults to `Back`.
+- `previous-label`: an override for the `stepPrevious` button label which defaults to `Back`.
 - `next-label`: an override for the `stepNext` button label which defaults to `Next`.
 
 ::Example


### PR DESCRIPTION
According to the code packages/addons/src/plugins/multiStep/sections/stepPrevious.ts, the props name for custom previous button label inside a multi step form should be named previous-label instead of prev-label