### PR TITLE
Fix typo in multi-step form name attribute.

### DIFF
--- a/plugins/multi-step.md
+++ b/plugins/multi-step.md
@@ -63,7 +63,7 @@ Using these inputs together is as simple as wrapping any markup you want to have
 
 ```html
 <FormKit type="multi-step">
-  <FormKit type="step" name: "stepOne">
+  <FormKit type="step" name="stepOne">
     <!-- content for stepOne goes here! -->
   </FormKit>
 </FormKit>


### PR DESCRIPTION
 The included example uses a colon instead of an equal sign to designate a step name. This will not work.

This PR fixes the issue.