### PR TITLE
Update select.md to name correct default icon

### DIFF
--- a/inputs/select.md
+++ b/inputs/select.md
@@ -151,7 +151,7 @@ data: [
     type: "String",
     default: "’’",
     description:
-      "Specifies <a href=&quot;/essentials/icons&quot;>an icon</a> to put in the <code>selectIcon</code> section. Defaults to the <code>down</code> icon.",
+      "Specifies <a href=&quot;/essentials/icons&quot;>an icon</a> to put in the <code>selectIcon</code> section. Defaults to the <code>select</code> icon.",
   },
 ]
 ---


### PR DESCRIPTION
The documentation states that the select component for FormKit uses the down icon as default but it is actually the select icon

See here line 62
https://github.com/formkit/formkit/blob/master/packages/inputs/src/inputs/select.ts