### PR TITLE
Add info about adding messages to custom rules

### DIFF
--- a/essentials/validation.md
+++ b/essentials/validation.md
@@ -735,6 +735,8 @@ Once installed you can use your validation rule in anywhere in your project.
 <FormKit validation="required|monday" />
 ```
 
+To customize the error message which shows up when your custom validation fails, follow the instructions [here](#global-validation-message).
+
 ### Adding a rule via prop
 
 To add a validation to a specific input use the `validation-rules` prop.


### PR DESCRIPTION
It was unclear to me how to add messages to custom validation rules. Eventually it seemed that just adding the messages in the config was the way to go. This PR adds a line describing that this is the way to do it.