### PR TITLE
docs: adds more callouts in schema

### DIFF
--- a/essentials/schema.md
+++ b/essentials/schema.md
@@ -206,9 +206,9 @@ layout: "auto"
 ::Callout
 ---
 type: "tip"
-label: "If input"
+label: "Ensure re-render with a key"
 ---
-When adding <code>if</code> to <code>$cmp</code> or <code>$formkit</code> that has an input vue might reuse the previous values and components for performance reasons, that may cause errors and unintended behaviour, because of that is advisable to add a unique <code>key</code> to that element so vue correctly rerenders the component.
+When adding an <code>if</code> property to <code>$cmp</code> or <code>$formkit</code> schema nodes that have dynamic values, Vue may reuse un-updated values and components for performance reasons. Adding a unique <code>key</code> property to the schema node will ensure Vue correctly re-renders the component.
 ::
 
 ### The `if/then/else` object
@@ -276,7 +276,7 @@ layout: "auto"
 type: "tip"
 label: "FormKit input slots"
 ---
-It is also possible to use already defined FormKit slots like <code>label</code> by mimicking the use of a slot with <code>__raw__sectionsSchema</code>, for more information on how to use raw values checkout the next sections.
+It is also possible to use already defined FormKit slots like <code>label</code> by mimicking the use of a slot with <code>__raw__sectionsSchema</code>. For more information on how to use raw values, checkout the "Raw values" section below.
 ::
 
 ## Binding attrs and props

--- a/essentials/schema.md
+++ b/essentials/schema.md
@@ -203,6 +203,14 @@ layout: "auto"
 ---
 ::
 
+::Callout
+---
+type: "tip"
+label: "If input"
+---
+When adding <code>if</code> to <code>$cmp</code> or <code>$formkit</code> that has an input vue might reuse the previous values and components for performance reasons, that may cause errors and unintended behaviour, because of that is advisable to add a unique <code>key</code> to that element so vue correctly rerenders the component.
+::
+
 ### The `if/then/else` object
 
 The `if/then/else` object allows for more complex conditional logic. It can be used to conditionally render nodes, a list of schema nodes, values of the `attrs` object or values of the `props` object. It is also possible to nest `if/then/else` objects to create more complex structures — similar to an `else if` statement in JavaScript.
@@ -261,6 +269,14 @@ name: "Schema - slots"
 file: "_content/_examples/schema-slots/schema-slots.vue"
 layout: "auto"
 ---
+::
+
+::Callout
+---
+type: "tip"
+label: "FormKit input slots"
+---
+It is also possible to use already defined FormKit slots like <code>label</code> by mimicking the use of a slot with <code>__raw__sectionsSchema</code>, for more information on how to use raw values checkout the next sections.
 ::
 
 ## Binding attrs and props

--- a/essentials/schema.md
+++ b/essentials/schema.md
@@ -276,7 +276,7 @@ layout: "auto"
 type: "tip"
 label: "FormKit input slots"
 ---
-It is also possible to use already defined FormKit slots like <code>label</code> by mimicking the use of a slot with <code>__raw__sectionsSchema</code>. For more information on how to use raw values, checkout the "Raw values" section below.
+Inside of a <code>$formkit</code> schema node, it is also possible to pass content to preexisting FormKit slots like <code>label</code> or <code>prefix</code> inside of the node's <code>__raw__sectionsSchema</code> property. Read more about raw values <a href="#raw-values">below</a>, and `sectionsSchema` in the <a href="/essentials/inputs/#sections-schema">inputs documentation</a>.
 ::
 
 ## Binding attrs and props


### PR DESCRIPTION
Adds two callouts in schema, one for adding a unique `key` when using a component or FormKit input with the `if` property, to properly rerender vue components.

The second being a citation that FormKit input slots can be mimicked in functionality with schema using the `__raw__sectionsSchema` property.