### PR TITLE
Reset messages to empty array on each submit

### DIFF
--- a/.examples/submit-invalid/submit-invalid.vue
+++ b/.examples/submit-invalid/submit-invalid.vue
@@ -7,6 +7,7 @@ const messages = ref([])
 
 function showErrors(node) {
   const validations = getValidationMessages(node)
+  messages.value = []
   validations.forEach((inputMessages) => {
     messages.value = messages.value.concat(
       inputMessages.map((message) => message.value)


### PR DESCRIPTION
This PR adds a single line to the "Extracting Messages" example in Essentials > Validation. It sets `messages.value` to an empty array each time `showErrors` is called, before looping through and concatenating current messages. This way, the messages will not be duplicated when form is submitted more than once.