### PR TITLE
Fix typos and a handful of punctuation issues

### DIFF
--- a/_install/astro.md
+++ b/_install/astro.md
@@ -40,7 +40,7 @@ label: "Vue Components"
 Astro does not let you use <code>FormKit</code> directly inside Astro files, so you should create a wrapper around your forms.
 ::
 
-Now you can add FormKit to your Astro Vue components, so that you can create a component inside the components folder:
+Now you can add FormKit to your Astro Vue components by creating a component inside the components folder:
 
 ```html
 <script setup>

--- a/_install/cli.md
+++ b/_install/cli.md
@@ -6,7 +6,7 @@ At your terminal, run `npx formkit@latest create-app` to start your new project:
 npx formkit@latest create-app
 ```
 
-`create-app` will ask you some questions about your project so it can determine what it needs to install and setup for you:
+`create-app` will ask you some questions about your project so it can determine what it needs to install and set up for you:
 
 ```sh
 ✔ Please enter a name for the project › <your-project-name>

--- a/_install/config.md
+++ b/_install/config.md
@@ -2,7 +2,7 @@
 
 To configure FormKit, create a FormKit config file in the root of your project and import it into your Vue App.
 
-If you would like to supply your own configuration, you can either extend `defaultConfig` by passing a [configuration object](/essentials/configuration#what-is-defaultconfig) to it, or replace with your own configuration object, which allows for improved tree-shaking (only include the rules and languages you need) and more fine-grained control:
+If you would like to supply your own configuration, you can either extend `defaultConfig` by passing a [configuration object](/essentials/configuration#what-is-defaultconfig) to it, or replace it with your own configuration object, which allows for improved tree-shaking (only include the rules and languages you need) and more fine-grained control:
 
 ::Callout
 ---

--- a/_install/nuxt.md
+++ b/_install/nuxt.md
@@ -31,4 +31,4 @@ export default defineNuxtConfig({
 })
 ```
 
-Though unstyled, FormKit is now registered using the default config and you can start using the `<FormKit>` component.
+Though unstyled, FormKit is now registered using the default config, and you can start using the `<FormKit>` component.

--- a/_install/pro-nuxt.md
+++ b/_install/pro-nuxt.md
@@ -42,9 +42,9 @@ export default defineFormKitConfig({
 type: "warning"
 label: "Legacy Genesis Theme"
 ---
-If you are using the legacy Genesis CSS, theme then follow the instructions below. 
+If you are using the legacy Genesis CSS theme, then follow the instructions below. 
 
-Note: All Tailwind themes from [themes.formkit.com](https://themes.formkit.com) ship with support for Pro Inputs so the instructions below are not required for Tailwind users.
+Note: All Tailwind themes from [themes.formkit.com](https://themes.formkit.com) ship with support for Pro Inputs, so the instructions below are not required for Tailwind users.
 ::
 
 If you are using the legacy Genesis CSS theme, you will need to install the accompanying Pro CSS as well:

--- a/_install/pro.md
+++ b/_install/pro.md
@@ -44,7 +44,7 @@ label: "Legacy Genesis Theme"
 ---
 If you are using the legacy Genesis CSS theme, then follow the instructions below. 
 
-Note: All Tailwind themes from [themes.formkit.com](https://themes.formkit.com) ship with support for Pro Inputs so the instructions below are not required for Tailwind users.
+Note: All Tailwind themes from [themes.formkit.com](https://themes.formkit.com) ship with support for Pro Inputs, so the instructions below are not required for Tailwind users.
 ::
 
 If you are using the legacy Genesis CSS theme, you will need to install the accompanying Pro CSS as well:

--- a/_install/styling-css.md
+++ b/_install/styling-css.md
@@ -10,7 +10,7 @@ FormKit now ships much more configurable Tailwind themes available at [themes.fo
 Eventually the legacy Genesis CSS theme will be deprecated and no longer supported by new Pro inputs.
 ::
 
-FormKit ships a (legacy) CSS theme called `genesis` which can be added by installed from the `@formkit/themes` package.
+FormKit ships a (legacy) CSS theme called `genesis` which can be added by installing from the `@formkit/themes` package.
 
 ### CDN Usage
 
@@ -39,7 +39,7 @@ import '@formkit/themes/genesis'
 
 ### Add required icons
 
-By default the icons required by the `genesis` theme will be loaded from CDN when requested. If you prefer to include the icons directly in your bundle for increased perfomance, to avoid any pop-in, or to alleviate possible SSR issues then import the `genesisIcons` set from `@formkit/icons` and spread them into the `icons` property of your FormKit config.
+By default the icons required by the `genesis` theme will be loaded from CDN when requested. If you prefer to include the icons directly in your bundle for increased performance, to avoid any pop-in, or to alleviate possible SSR issues, then import the `genesisIcons` set from `@formkit/icons` and spread them into the `icons` property of your FormKit config.
 
 ```js
 import { genesisIcons } from '@formkit/icons'

--- a/_install/styling-tailwind.md
+++ b/_install/styling-tailwind.md
@@ -4,7 +4,7 @@
 
 ### Adding icons
 
-By default, the icons required by FormKit will be loaded from CDN when requested. If you prefer to include the icons directly in your bundle for increased perfomance, to avoid any pop-in, or to alleviate possible SSR issues, then import the `genesisIcons` set from `@formkit/icons` and spread them into the `icons` property of your FormKit config:
+By default, the icons required by FormKit will be loaded from CDN when requested. If you prefer to include the icons directly in your bundle for increased performance, to avoid any pop-in, or to alleviate possible SSR issues, then import the `genesisIcons` set from `@formkit/icons` and spread them into the `icons` property of your FormKit config:
 
 ```sh
 npm install @formkit/icons

--- a/_install/styling-uno.md
+++ b/_install/styling-uno.md
@@ -1,6 +1,6 @@
 ### For Tailwind
 
-FormKit ships with a Tailwind version of the Genesis theme. To use this pre-made Tailwind theme in your project import it from `@formkit/themes/tailwindcss/genesis` and add it to your `formkit.config.js`. You'll also want to include the neccessary `genesisIcons` import from `@formkit/icons`.
+FormKit ships with a Tailwind version of the Genesis theme. To use this pre-made Tailwind theme in your project, import it from `@formkit/themes/tailwindcss/genesis` and add it to your `formkit.config.js`. You'll also want to include the necessary `genesisIcons` import from `@formkit/icons`.
 
 ```js
 // formkit.config.js
@@ -18,7 +18,7 @@ export default {
 }
 ```
 
-The `genesis` theme import is nice for brevity, but the Tailwind parser will need to be provided the path to the full theme file in your `node_modules` in order to know which classes are being used. Additionally you should add the `FormKitVariants` plugin to your `tailwind.config.js` in order to make use of helpful FormKit variants such as `formkit-invalid:` in your project.
+The `genesis` theme import is nice for brevity, but the Tailwind parser will need to be provided the path to the full theme file in your `node_modules` in order to know which classes are being used. Additionally, you should add the `FormKitVariants` plugin to your `tailwind.config.js` in order to make use of helpful FormKit variants such as `formkit-invalid:` in your project.
 
 ```js
 // tailwind.config.js

--- a/_install/styling-windi.md
+++ b/_install/styling-windi.md
@@ -1,6 +1,6 @@
 ### For Tailwind
 
-FormKit ships with a Tailwind version of the Genesis theme. To use this pre-made Tailwind theme in your project import it from `@formkit/themes/tailwindcss/genesis` and add it to your `formkit.config.js`. You'll also want to include the neccessary `genesisIcons` import from `@formkit/icons`.
+FormKit ships with a Tailwind version of the Genesis theme. To use this pre-made Tailwind theme in your project, import it from `@formkit/themes/tailwindcss/genesis` and add it to your `formkit.config.js`. You'll also want to include the necessary `genesisIcons` import from `@formkit/icons`.
 
 ```js
 // formkit.config.js
@@ -18,7 +18,7 @@ export default {
 }
 ```
 
-The `genesis` theme import is nice for brevity, but the Tailwind parser will need to be provided the path to the full theme file in your `node_modules` in order to know which classes are being used. Additionally you should add the `FormKitVariants` plugin to your `tailwind.config.js` in order to make use of helpful FormKit variants such as `formkit-invalid:` in your project.
+The `genesis` theme import is nice for brevity, but the Tailwind parser will need to be provided the path to the full theme file in your `node_modules` in order to know which classes are being used. Additionally, you should add the `FormKitVariants` plugin to your `tailwind.config.js` in order to make use of helpful FormKit variants such as `formkit-invalid:` in your project.
 
 ```js
 // tailwind.config.js

--- a/_install/tailwind-install-instructions.md
+++ b/_install/tailwind-install-instructions.md
@@ -19,7 +19,7 @@ Alternatively, you can use the FormKit CLI to select a theme for your project. R
 npx formkit@latest theme
 ```
 
-This command will create a `formkit.theme.{ts|js}` file in the root of your project. To complete the setup you will need use the `rootClasses` from this theme file in your `formkit.config.{ts|js}`:
+This command will create a `formkit.theme.{ts|js}` file in the root of your project. To complete the setup you will need to use the `rootClasses` from this theme file in your `formkit.config.{ts|js}`:
 
 ```js
 // formkit.config.ts


### PR DESCRIPTION
This PR fixes some typos and punctuation issues in the _install directory. As always, let me know if anything needs clarification